### PR TITLE
Add Always on Top option

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -10,6 +10,7 @@ var globalShortcut = electron.globalShortcut;
 var BrowserWindow = electron.BrowserWindow;
 
 global.sharedObject = {
+    alwaysOnTop: false,
     hideNSFW: true,
     includeHashTag: true,
     hideOnCopy: true,
@@ -24,7 +25,6 @@ var options = {
     height: 600,
     resizable: false,
     tooltip: 'GifBar',
-    'always-on-top': true,
     preloadWindow: true,
     icon: path.join(__dirname, 'gifbar-icon.png')
 };
@@ -112,11 +112,7 @@ function create (opts) {
 
             menubar.positioner = new Positioner(menubar.window);
 
-            if (!opts['always-on-top']) {
-                menubar.window.on('blur', hideWindow);
-            } else {
-                menubar.window.on('blur', emitBlur);
-            }
+            setWindowAlwaysOnTop();
 
             if (opts['show-on-all-workspaces'] !== false) {
                 menubar.window.setVisibleOnAllWorkspaces(true);
@@ -125,6 +121,19 @@ function create (opts) {
             menubar.window.on('close', windowClear);
             menubar.window.loadURL(opts.index);
             menubar.emit('after-create-window');
+        }
+
+        function setWindowAlwaysOnTop() {
+            menubar.window.removeListener('blur', emitBlur);
+            menubar.window.removeListener('blur', hideWindow);
+
+            menubar.window.setAlwaysOnTop(global.sharedObject.alwaysOnTop, 'floating');
+
+            if (global.sharedObject.alwaysOnTop) {
+                menubar.window.on('blur', emitBlur);
+            } else {
+                menubar.window.on('blur', hideWindow);
+            }
         }
 
         function showWindow (trayPos) {
@@ -179,6 +188,28 @@ function create (opts) {
 
         function showDetailMenu () {
             var contextMenu = Menu.buildFromTemplate([
+                {
+                    label: 'Show GifBar',
+                    click: function() {
+                        showWindow(cachedBounds);
+                    }
+                },
+                {
+                    type: 'separator'
+                },
+                {
+                    label: 'Preferences',
+                    enabled: false
+                },
+                {
+                    label: 'Always on Top',
+                    type: 'checkbox',
+                    checked: global.sharedObject.alwaysOnTop,
+                    click: function() {
+                        global.sharedObject.alwaysOnTop = !global.sharedObject.alwaysOnTop;
+                        setWindowAlwaysOnTop();
+                    }
+                },
                 {
                     label: 'Hide NSFW',
                     type: 'checkbox',


### PR DESCRIPTION
A working always on top option in preferences.

Also, when always on top is off the window now correctly disappears when it loses focus. No more clicking the icon twice to get the window to show.

Also added a 'Show GifBar' menu entry.

![boom](https://media3.giphy.com/media/WDtCGLCXBAgow/giphy.gif)