### PR TITLE
Fix typo: DevToools

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -215,12 +215,15 @@ function create (opts) {
                     type: 'separator'
                 },
                 {
-                    label: 'Toggle DevToools',
+                    label: 'Toggle DevTools',
                     accelerator: 'Alt+Command+I',
                     click: function() {
                         menubar.window.show();
                         menubar.window.toggleDevTools();
                     }
+                },
+                {
+                    type: 'separator'
                 },
                 {
                     label: 'Quit',


### PR DESCRIPTION
Also added another menu separator under DevTools.

![mistake](https://media4.giphy.com/media/XpYWfAlJXphWE/giphy.gif)