### PR TITLE
Use `electron-settings` to persist settings.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -9,6 +9,7 @@ mkdir build/node_modules
 cp -a node_modules/applescript build/node_modules/
 cp -a node_modules/auto-launch-patched build/node_modules/
 cp -a node_modules/electron-positioner build/node_modules/
+cp -a node_modules/electron-settings build/node_modules/
 cp -a node_modules/extend build/node_modules/
 cp -a node_modules/mkdirp build/node_modules/
 cp -a node_modules/path-is-absolute build/node_modules/

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "electron-packager": "^8.6.0",
     "electron-positioner": "^3.0.0",
     "electron-prebuilt": "^1.4.13",
+    "electron-settings": "~3.1.1",
     "es6-shim": "^0.35.3",
     "eslint-plugin-react": "^6.10.3",
     "extend": "^3.0.0",

--- a/src/main.js
+++ b/src/main.js
@@ -9,7 +9,7 @@ var Menu = electron.Menu;
 var globalShortcut = electron.globalShortcut;
 var BrowserWindow = electron.BrowserWindow;
 
-const settings = require('electron-settings');
+var settings = require('electron-settings');
 
 global.sharedObject = {
     alwaysOnTop:    settings.get('alwaysOnTop', false),

--- a/src/main.js
+++ b/src/main.js
@@ -9,13 +9,15 @@ var Menu = electron.Menu;
 var globalShortcut = electron.globalShortcut;
 var BrowserWindow = electron.BrowserWindow;
 
+const settings = require('electron-settings');
+
 global.sharedObject = {
-    alwaysOnTop: false,
-    hideNSFW: true,
-    includeHashTag: true,
-    hideOnCopy: true,
-    launchAtLogin: false,
-    globalShortcut: true
+    alwaysOnTop:    settings.get('alwaysOnTop', false),
+    hideNSFW:       settings.get('hideNSFW', true),
+    includeHashTag: settings.get('includeHashTag', true),
+    hideOnCopy:     settings.get('hideOnCopy', true),
+    launchAtLogin:  false, // setting not necessary as the OS handles that.
+    globalShortcut: settings.get('globalShortcut', true)
 };
 
 var extend = require('extend');
@@ -221,6 +223,7 @@ function create (opts) {
                     click: function() {
                         global.sharedObject.alwaysOnTop = !global.sharedObject.alwaysOnTop;
                         setWindowAlwaysOnTop();
+                        settings.set('alwaysOnTop', global.sharedObject.alwaysOnTop);
                     }
                 },
                 {
@@ -229,6 +232,7 @@ function create (opts) {
                     checked: global.sharedObject.hideNSFW,
                     click: function() {
                         global.sharedObject.hideNSFW = !global.sharedObject.hideNSFW;
+                        settings.set('hideNSFW', global.sharedObject.hideNSFW);
                     }
                 },
                 {
@@ -237,6 +241,7 @@ function create (opts) {
                     checked: global.sharedObject.includeHashTag,
                     click: function() {
                         global.sharedObject.includeHashTag = !global.sharedObject.includeHashTag;
+                        settings.set('includeHashTag', global.sharedObject.includeHashTag);
                     }
                 },
                 {
@@ -245,6 +250,7 @@ function create (opts) {
                     checked: global.sharedObject.hideOnCopy,
                     click: function() {
                         global.sharedObject.hideOnCopy = !global.sharedObject.hideOnCopy;
+                        settings.set('hideOnCopy', global.sharedObject.hideOnCopy);
                     }
                 },
                 {
@@ -253,6 +259,7 @@ function create (opts) {
                     checked: global.sharedObject.globalShortcut,
                     click: function() {
                         global.sharedObject.globalShortcut = !global.sharedObject.globalShortcut;
+                        settings.set('globalShortcut', global.sharedObject.globalShortcut);
                     }
                 },
                 {

--- a/src/package.json
+++ b/src/package.json
@@ -6,6 +6,7 @@
     "applescript": "^1.0.0",
     "auto-launch-patched": "~5.0.2",
     "electron-positioner": "^3.0.0",
+    "electron-settings": "~3.1.1",
     "extend": "^3.0.0",
     "mkdirp": "^0.5.1",
     "path-is-absolute": "^1.0.0",


### PR DESCRIPTION
Fixes #53

Settings persist.

Only tested on MacOS.