### PR TITLE
Remove unnecessary `setState` that breaks pagination.

### DIFF
--- a/src/app/containers/main/index.jsx
+++ b/src/app/containers/main/index.jsx
@@ -62,8 +62,6 @@ class Main extends Component {
 
     @autobind
     searchRequest(searchTerm, offset) {
-        this.setState(initialState);
-
         if (searchTerm) {
             this.setState({
                 status: {


### PR DESCRIPTION
Fixes #78

I don't remember why I added that `setState` in the first place, but it all seems fine without it.

![everything is fine](https://media2.giphy.com/media/xT5LMwb7DuoIsflpEA/giphy.gif)