### PR TITLE
Don't add a favorite if the image already exists in favorites

### DIFF
--- a/src/app/favorites.js
+++ b/src/app/favorites.js
@@ -14,8 +14,11 @@ storage.get(`favorites`, (error, data) => {
 });
 
 export function storeFavorite(image) {
-  favorites.push(image);
-  saveFavorites();
+  const exists = favorites.some((img) => img.id === image.id);
+  if (!exists) {
+    favorites.push(image);
+    saveFavorites();
+  }
 }
 
 export function getFavorites(amount=20, offset=0) {


### PR DESCRIPTION
You can currently add a favorite more than once.

<img width="548" alt="screenshot 2019-02-22 16 23 16" src="https://user-images.githubusercontent.com/136891/53271978-03fb5580-36be-11e9-8741-a7fae42f8b39.png">

![oh no](https://media3.giphy.com/media/14aUO0Mf7dWDXW/giphy.gif?cid=e1bb72ff5c7054234f5a69424d9567fe)